### PR TITLE
Add showCaptureOverlay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ TakePicture::make('camera_test')
     ->disk('public')
     ->directory('uploads/services/payment_receipts_proof')
     ->visibility('public')
+    ->showCaptureOverlay(true)
     ->showCameraSelector(true)
     ->aspect('16:9')
     ->imageQuality(80)
@@ -53,6 +54,7 @@ TakePicture::make('camera_test')
 | `directory(string $directory)` | Set the directory path within the disk where photos will be stored |
 | `visibility(string $visibility)` | Set the file visibility (e.g., 'public', 'private') |
 | `showCameraSelector(bool $showSelector)` | Enable or disable camera selection option for devices with multiple cameras (default: 'true') |
+| `showCaptureOverlay(bool $showOverlay)` | Enable or disable the capture overlay (default: 'true') |
 | `aspect(string $aspect)` | Set the aspect ratio for the captured image (e.g., '16:9', '4:3', '1:1') |
 | `imageQuality(int $quality)` | Set the JPEG quality of the captured image (0-100) |
 | `shouldDeleteOnEdit(bool $shouldDelete)` | Whether to delete the previous file when editing (default: 'false') |

--- a/resources/views/forms/components/take-picture.blade.php
+++ b/resources/views/forms/components/take-picture.blade.php
@@ -13,6 +13,7 @@
             selectedCameraId: null,
             modalOpen: false,
             showingPreview: false,
+            showCaptureOverlay: {{ $getShowCaptureOverlay() ? 'true' : 'false' }},
             aspectRatio: '{{ $getAspect() }}',
             imageQuality: {{ $getImageQuality() }},
             maxWidth: {{ $getCaptureMaxWidth() ?? 'null' }},
@@ -536,7 +537,7 @@
                             </div>
 
                             <!-- Capture button overlay -->
-                            <div x-show="webcamActive && !webcamError && !showingPreview" class="absolute bottom-4 left-0 right-0 flex justify-center">
+                            <div x-show="webcamActive && !webcamError && !showingPreview && showCaptureOverlay" class="absolute bottom-4 left-0 right-0 flex justify-center">
                                 <button type="button" @click="capturePhoto()" class="w-16 h-16 rounded-full bg-primary-600 hover:bg-primary-500 border-4 border-white flex items-center justify-center shadow-lg transition-colors" title="{{ __('Take Photo') }}">
                                     <x-filament::icon icon="heroicon-s-camera" class="h-8 w-8 text-white" />
                                 </button>

--- a/src/Forms/Components/TakePicture.php
+++ b/src/Forms/Components/TakePicture.php
@@ -16,6 +16,7 @@ class TakePicture extends Field
     protected ?string $targetField = null;
     protected bool $shouldDeleteTemporaryFile = true;
     protected bool $showCameraSelector = false;
+    protected bool $showCaptureOverlay = false;
     protected int $imageQuality = 90;
     protected string $aspect = '16:9';
     protected bool $useModal = true;
@@ -58,6 +59,12 @@ class TakePicture extends Field
     public function showCameraSelector(bool $show = true): static
     {
         $this->showCameraSelector = $show;
+        return $this;
+    }
+
+    public function showCaptureOverlay(bool $show = true): static
+    {
+        $this->showCaptureOverlay = $show;
         return $this;
     }
 
@@ -137,6 +144,11 @@ class TakePicture extends Field
     public function getImageQuality(): int
     {
         return $this->imageQuality;
+    }
+
+    public function getShowCaptureOverlay(): bool
+    {
+        return $this->showCaptureOverlay;
     }
 
     public function getAspect(): string


### PR DESCRIPTION
This pull request adds a new feature to the `TakePicture` form component,  to enable or disable a capture overlay (the capture button UI) when using the camera. The feature is configurable via a new method, and is documented in the README

### Feature: Capture Overlay Toggle

* Added a new `showCaptureOverlay(bool $show = true)` method and corresponding property to the `TakePicture` component, allowing the capture overlay to be enabled or disabled.
* Updated the Blade component (`take-picture.blade.php`) to use the new `showCaptureOverlay` property and conditionally display the capture button overlay based on its value.

### Documentation

* Updated the `README.md` to document the new `showCaptureOverlay` method